### PR TITLE
Fix crasher in Get-WiFiProfile

### DIFF
--- a/WiFiProfileManagement.psm1
+++ b/WiFiProfileManagement.psm1
@@ -234,6 +234,7 @@ function Get-WiFiProfile
     }
     process
     {        
+        [Guid]$interfaceGuid = (Get-NetAdapter -Name $WiFiAdapterName).interfaceguid
         if (!$ProfileName)
         {
             [WiFi.ProfileManagement]::WlanGetProfileList($clientHandle,$interfaceGUID,[IntPtr]::zero,[ref]$ProfileListPtr) | Out-Null


### PR DESCRIPTION
Fixes the Get-WiFiProfile function and prevents error caused by `$interfaceGuid` being undefined.

Without this line the following error appears

```
PS C:\>  Get-WiFiProfile
Cannot convert argument "interfaceGuid", with value: "", for "WlanGetProfileList" to type "System.Guid": "Cannot convert null to type "System.Guid"."
At C:\Users\jim\Documents\WindowsPowerShell\Modules\WiFiProfileManagement\WiFiProfileManagement.psm1:240 char:13
+             [WiFi.ProfileManagement]::WlanGetProfileList($clientHandl ...
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodException
    + FullyQualifiedErrorId : MethodArgumentConversionInvalidCastArgument
```

...followed by a 'powershell has stopped working' dialog that requires the user to close the program (PS console).
