### PR TITLE
Feature/wlan enum interfaces

### DIFF
--- a/AddNativeWiFiFunctions.ps1
+++ b/AddNativeWiFiFunctions.ps1
@@ -195,7 +195,7 @@ $WlanGetProfileListSig = @'
         public DOT11_CIPHER_ALGORITHM dot11DefaultCipherAlgorithm;
         public uint dwFlags;
         public uint dwReserved;
-    }       
+    }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
     public struct DOT11_SSID

--- a/WiFiProfileManagement.psm1
+++ b/WiFiProfileManagement.psm1
@@ -124,7 +124,7 @@ function Get-WiFiProfileInfo
     {
         $profileInfoResult = [WiFi.ProfileManagement]::WlanGetProfile($ClientHandle,$InterfaceGuid,$ProfileName,[IntPtr]::Zero,[ref]$pstrProfileXml,[ref]$WlanProfileFlags,[ref]$wlanAccess)
 
-        If ($profileInfoResult -eq 1168)
+        if ($profileInfoResult -eq 1168)
         {
             return
         }

--- a/WiFiProfileManagement.psm1
+++ b/WiFiProfileManagement.psm1
@@ -755,3 +755,26 @@ function Get-WiFiAvailableNetwork
         Remove-WiFiHandle -ClientHandle $clientHandle
     }
 }
+
+<#
+    .SYNOPSIS
+        Lists the wireless interfaces and their state.  
+#>
+    function Get-WiFiInterface
+    {
+        [CmdletBinding()]
+        [OutputType([WiFi.ProfileManagement+WLAN_INTERFACE_INFO])]
+
+        $InterfaceListPtr = 0
+        $clientHandle = New-WiFiHandle
+
+        [WiFi.ProfileManagement]::WlanEnumInterfaces($clientHandle,[IntPtr]::zero,[ref]$InterfaceListPtr) | Out-Null
+        $WiFiInterfaceList = [WiFi.ProfileManagement+WLAN_INTERFACE_INFO_LIST]::new($InterfaceListPtr)
+
+        Remove-WiFiHandle -ClientHandle $clientHandle
+
+        foreach ($wlanInterfaceInfo in $WiFiInterfaceList.wlanInterfaceInfo)
+        {
+            [WiFi.ProfileManagement+WLAN_INTERFACE_INFO]$wlanInterfaceInfo
+        }
+    }


### PR DESCRIPTION
First bash at implementing idea mentioned in https://github.com/jcwalker/WiFiProfileManagement/issues/13 of enumerating all WiFi interfaces in exported functions that assume a default adapter name of 'Wi-Fi'.

This is my first time looking at PS in ~4 years and I've never wrapped native APIs so took a very much 'monkey-see-monkey-do' approach to writing this based on the existing code. Feedback welcome! :)

The non-exported function `Get-WiFiInterface` returns the following type of output:

```
PS > Get-WiFiInterface

Guid                                 Description                                                            State
----                                 -----------                                                            -----
d73b8ac7-da0e-462b-8a32-5f75d7eba490 Intel(R) Dual Band Wireless-AC 8265                             disconnected
4a420979-ff77-40eb-9d92-0e2d073538c1 Realtek RTL8811AU Wireless LAN 802.11ac USB 2.0 Network Adapter disconnected
```

This PR changes the behavior of `Get-WiFiProfile` like so:

Running with single built in WiFi adapter named 'WiFi':

```
PS > Get-WiFiProfile

ProfileName               ConnectionMode Authentication Encyption Password
-----------               -------------- -------------- --------- --------
ScotRail free wifi        manual         open           none
iPhone                    auto           WPA2PSK        AES
BTHub5-NM2K               auto           WPA2PSK        AES
Staff                     auto           WPA2PSK        AES
```

Running with additional USB WiFi adapter plugged in (named 'Wi-Fi 2'):

```
PS > Get-WiFiProfile

ProfileName               ConnectionMode Authentication Encyption Password
-----------               -------------- -------------- --------- --------
ScotRail free wifi        manual         open           none
iPhone                    auto           WPA2PSK        AES
BTHub5-NM2K               auto           WPA2PSK        AES
Staff                     auto           WPA2PSK        AES
BTWifi-with-FON           manual         open           none
```

It picks up the additional BTWifi-with-FON profile on that adapter.

The original behavior when passing -WiFiAdapterName is preserved:

```
PS > Get-WiFiProfile -WiFiAdapterName WiFi

ProfileName               ConnectionMode Authentication Encyption Password
-----------               -------------- -------------- --------- --------
ScotRail free wifi        manual         open           none
iPhone                    auto           WPA2PSK        AES
BTHub5-NM2K               auto           WPA2PSK        AES
Staff                     auto           WPA2PSK        AES
```

This PR shouldn't be merged right now as I've not made similar changes to `Get-WiFiAvailableNetwork` yet. I'm just looking for some feedback before I go ahead with anything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jcwalker/wifiprofilemanagement/14)
<!-- Reviewable:end -->
